### PR TITLE
End date in notices made optional

### DIFF
--- a/TenureInformationApi/V1/Domain/Notices.cs
+++ b/TenureInformationApi/V1/Domain/Notices.cs
@@ -11,6 +11,6 @@ namespace TenureInformationApi.V1.Domain
         public DateTime ExpiryDate { get; set; }
 
         public DateTime EffectiveDate { get; set; }
-        public DateTime EndDate { get; set; }
+        public DateTime? EndDate { get; set; }
     }
 }


### PR DESCRIPTION
The API is failing in development due to the EndDate value in Notices being null, Hence I have made the value to be optional 