### PR TITLE
Updated tenure api to include additional household member fields

### DIFF
--- a/TenureInformationApi/V1/Domain/Enums.cs
+++ b/TenureInformationApi/V1/Domain/Enums.cs
@@ -15,4 +15,11 @@ namespace TenureInformationApi.V1.Domain
         Dwelling,
         Garage
     }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum PersonTenureType
+    {
+        Tenant,
+        Leaseholder,
+        Freeholder
+    }
 }

--- a/TenureInformationApi/V1/Domain/HouseholdMembers.cs
+++ b/TenureInformationApi/V1/Domain/HouseholdMembers.cs
@@ -11,5 +11,8 @@ namespace TenureInformationApi.V1.Domain
         public string FullName { get; set; }
 
         public bool IsResponsible { get; set; }
+
+        public DateTime DateOfBirth { get; set; }
+        public PersonTenureType PersonTenureType { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

[https://hackney.atlassian.net/browse/MTTL-708](https://hackney.atlassian.net/browse/MTTL-708)
## Describe this PR

I have updated the get tenure API to include the following additional fields in household members:

- [x] DateOfBirth 
- [x] PersonTenureType (Tenant/Leaseholder/Freeholder)  

Let me know if there are any other additional fields that will need to be added 