### PR TITLE
Allow tenuredAssetType to be null

### DIFF
--- a/TenureInformationApi/V1/Domain/TenuredAsset.cs
+++ b/TenureInformationApi/V1/Domain/TenuredAsset.cs
@@ -6,7 +6,7 @@ namespace TenureInformationApi.V1.Domain
     {
         public Guid Id { get; set; }
 
-        public TenuredAssetType Type { get; set; }
+        public TenuredAssetType? Type { get; set; }
 
         public string FullAddress { get; set; }
 


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

For tenures that have an agreement of type "Sundry" and some subsidiary tenures, the asset linked to the tenure does not always exist, therefore the `TenuredAssetType` is NULL which makes the API fail.

### *What changes have we introduced*

Make the field `TenuredAssetType` nullable.
