### PR TITLE
Bugfix - 500 When Tenure has no VersionNumber

### DIFF
--- a/TenureInformationApi.Tests/V1/Controllers/TenureInformationControllerTests.cs
+++ b/TenureInformationApi.Tests/V1/Controllers/TenureInformationControllerTests.cs
@@ -145,6 +145,31 @@ namespace TenureInformationApi.Tests.V1.Controllers
         }
 
         [Fact]
+        public async Task GetTenureWhenVersionNumberIsNullReturnsETAGOfZeroAsync()
+        {
+            // when versionNumber is null, ETAG is set to 0
+
+            // Arrange
+            var mockTenureResponse = _fixture.Build<TenureInformation>()
+                .With(x => x.VersionNumber, (int?) null)
+                .Create();
+
+            var mockRequest = ConstructRequest(mockTenureResponse.Id);
+
+            _mockGetByIdUsecase.Setup(x => x.Execute(mockRequest)).ReturnsAsync(mockTenureResponse);
+
+            // Act
+            var response = await _classUnderTest.GetByID(mockRequest).ConfigureAwait(false);
+
+            // Assert ETAG value is 0, no error thrown
+            var expectedEtagValue = $"\"0\"";
+            _classUnderTest.HttpContext.Response.Headers.TryGetValue(HeaderConstants.ETag, out StringValues val).Should().BeTrue();
+            val.First().Should().Be(expectedEtagValue);
+
+
+        }
+
+        [Fact]
         public async Task PostNewTenureIdAsyncFoundReturnsResponse()
         {
             // Arrange

--- a/TenureInformationApi.Tests/V1/Controllers/TenureInformationControllerTests.cs
+++ b/TenureInformationApi.Tests/V1/Controllers/TenureInformationControllerTests.cs
@@ -145,7 +145,7 @@ namespace TenureInformationApi.Tests.V1.Controllers
         }
 
         [Fact]
-        public async Task GetTenureWhenVersionNumberIsNullReturnsETAGOfZeroAsync()
+        public async Task GetTenureWhenVersionNumberIsNullReturnsEmptyETAG()
         {
             // when versionNumber is null, ETAG is set to 0
 
@@ -162,11 +162,9 @@ namespace TenureInformationApi.Tests.V1.Controllers
             var response = await _classUnderTest.GetByID(mockRequest).ConfigureAwait(false);
 
             // Assert ETAG value is 0, no error thrown
-            var expectedEtagValue = $"\"0\"";
+            var expectedEtagValue = $"\"\"";
             _classUnderTest.HttpContext.Response.Headers.TryGetValue(HeaderConstants.ETag, out StringValues val).Should().BeTrue();
             val.First().Should().Be(expectedEtagValue);
-
-
         }
 
         [Fact]

--- a/TenureInformationApi/V1/Controllers/TenureInformationController.cs
+++ b/TenureInformationApi/V1/Controllers/TenureInformationController.cs
@@ -62,9 +62,12 @@ namespace TenureInformationApi.V1.Controllers
             var result = await _getByIdUseCase.Execute(query).ConfigureAwait(false);
             if (result == null) return NotFound(query.Id);
 
-            int versionNumber = (result.VersionNumber != null) ? result.VersionNumber.Value : 0;
+            var eTag = string.Empty;
+            if (result.VersionNumber.HasValue)
+                eTag = result.VersionNumber.ToString();
 
-            HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{versionNumber}\"").Tag);
+            HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{eTag}\"").Tag);
+
             return Ok(result.ToResponse());
         }
 

--- a/TenureInformationApi/V1/Controllers/TenureInformationController.cs
+++ b/TenureInformationApi/V1/Controllers/TenureInformationController.cs
@@ -62,7 +62,9 @@ namespace TenureInformationApi.V1.Controllers
             var result = await _getByIdUseCase.Execute(query).ConfigureAwait(false);
             if (result == null) return NotFound(query.Id);
 
-            HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{result.VersionNumber.Value}\"").Tag);
+            int versionNumber = (result.VersionNumber != null) ? result.VersionNumber.Value : 0;
+
+            HttpContext.Response.Headers.Add(HeaderConstants.ETag, EntityTagHeaderValue.Parse($"\"{versionNumber}\"").Tag);
             return Ok(result.ToResponse());
         }
 


### PR DESCRIPTION
TenureAPI /GetByID

Add nullcheck when reading tenure versionNumber. Returns "" if null.

The VersionNumber property was recently added to TenureInformationDb. Tenures that havent been edited yet will have this set to null.

```
[DynamoDBVersion]
public int? VersionNumber { get; set; }
```
I've added a check in the GetByID controller method to test if this value is null (was throwing 500 exception).

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

